### PR TITLE
Fix turret

### DIFF
--- a/content/blocks/golden-duo.json
+++ b/content/blocks/golden-duo.json
@@ -1,5 +1,5 @@
 {
-    "type": "DoubleTurret",
+    "type": "ItemTurret",
     "name": "Golden Duo",
     "description": "A duo but golden",
 
@@ -10,8 +10,10 @@
     "range": 256,
     "inaccuracy": 30,
     "rotatespeed": 12,
+    "alternate": true,
+    "shots": 2,
 
-    "ammoUseEffect": "shellEjectSmall",
+    "ammoUseEffect": "none",
 
     "ammoTypes": {
         "copper": {


### PR DESCRIPTION
Because "DoubleTurret" is not in V6, you need "Alternate" to make this work.